### PR TITLE
When we zoom to coordinates from location search, we need to turn GPS…

### DIFF
--- a/frontend/src/features/ol_map/olMap.tsx
+++ b/frontend/src/features/ol_map/olMap.tsx
@@ -128,6 +128,7 @@ function OLMap(props: Props) {
 
 	useEffect(() => {
 		if (mapRef.current !== undefined && zoomToCoordinates !== undefined) {
+			setIsFollowingGPS(false);
 			updateAndCentreMapOnPosition(mapRef.current, zoomToCoordinates);
 			dispatch(setSearchLocationsZoomToCoordinates(undefined));
 		}


### PR DESCRIPTION
… location snapping OFF